### PR TITLE
Fix: exercise 3 hint link

### DIFF
--- a/exercises/exercise-03/index.ts
+++ b/exercises/exercise-03/index.ts
@@ -76,4 +76,4 @@ console.log(chalk.yellow('Users:'));
 persons.filter(isUser).forEach(logPerson);
 
 // In case if you are stuck:
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#typeof-type-guards
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates


### PR DESCRIPTION
If I understand correctly, this exercise is supposed to be solved with "type predicates", but the url leads to the docs section about "typeof" type guards.